### PR TITLE
makes basic memory display work on OSx 10.8.x by using psutil's provided available attr

### DIFF
--- a/vendor/basic-cpu-and-memory.tmux
+++ b/vendor/basic-cpu-and-memory.tmux
@@ -26,11 +26,10 @@ def get_dashes(perc):
 
 def info():
     mem = psutil.virtual_memory()
-    memused = mem.used - mem.cached
 
     cpu_dashes, cpu_empty_dashes = get_dashes(psutil.cpu_percent(interval=0.1))
     line = "%s/%sMB [%s%s] %s%%" % (
-        str(int(memused / 1024 / 1024)),
+        str(int(mem.available / 1024 / 1024)),
         str(int(mem.total / 1024 / 1024)),
         cpu_dashes, cpu_empty_dashes,
         psutil.cpu_percent(interval=0.1),


### PR DESCRIPTION
The `cached` attr used to work on BSD/OSx but no longer does. However psutil provides a
useful `available` attr that seems to do the same calculation taking into account platform
differences.  According to psutils docs `available` is "the actual amount of available
memory that can be given instantly to processes that request more memory in bytes; this is
calculated by summing different memory values depending on the platform (e.g. free + buffers
    + cached on Linux) and it is supposed to be used to monitor actual memory usage in
a cross platform fashion.".

via http://code.google.com/p/psutil/wiki/Documentation#Memory
