### PR TITLE
Fix error "Fail to connect to server" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ sudo make install
 cd ~
 ```
 
+  Launch tmux:
+```
+tmux
+```
+  And press `Control + a` then `d` to go back to the terminal.
+
   Update config:
 
 ```bash


### PR DESCRIPTION
When using `tmux source-file ~/.tmux.conf` like in the README we getting an error `failed to connect to server`. We have to run **tmux** and detached it to do be able to do the command.
