### PR TITLE
Use new tmux-mem-cpu-load args format

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -37,7 +37,7 @@ set -g status-justify centre # center align window list
 set -g status-left-length 20
 set -g status-right-length 140
 set -g status-left '#[fg=green]#H #[fg=black]• #[fg=green,bright]#(uname -r | cut -c 1-6)#[default]'
-set -g status-right '#[fg=green,bg=default,bright]#(tmux-mem-cpu-load 1) #[fg=red,dim,bg=default]#(uptime | cut -f 4-5 -d " " | cut -f 1 -d ",") #[fg=white,bg=default]%a%l:%M:%S %p#[default] #[fg=blue]%Y-%m-%d'
+set -g status-right '#[fg=green,bg=default,bright]#(tmux-mem-cpu-load -i 1) #[fg=red,dim,bg=default]#(uptime | cut -f 4-5 -d " " | cut -f 1 -d ",") #[fg=white,bg=default]%a%l:%M:%S %p#[default] #[fg=blue]%Y-%m-%d'
 
 # C-b is not acceptable -- Vim uses it
 set-option -g prefix C-a


### PR DESCRIPTION
tmux-mem-cpu-load now requires the interval to be passed with -i

As reported in https://github.com/thewtex/tmux-mem-cpu-load/issues/24