### PR TITLE
Use new mouse option for tmux >= 2.1

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -84,9 +84,6 @@ bind r source-file ~/.tmux.conf \; display-message "Config reloaded..."
 # auto window rename
 set-window-option -g automatic-rename
 
-# rm mouse mode fail
-set -g mode-mouse off
-
 # color
 set -g default-terminal "screen-256color"
 
@@ -100,6 +97,11 @@ set-option -g status-utf8 on
 run-shell "tmux set-environment -g TMUX_VERSION_MAJOR $(tmux -V | cut -d' ' -f2 | cut -d'.' -f1 | sed 's/[^0-9]*//g')"
 run-shell "tmux set-environment -g TMUX_VERSION_MINOR $(tmux -V | cut -d' ' -f2 | cut -d'.' -f2 | sed 's/[^0-9]*//g')"
 
+# rm mouse mode fail
+if-shell '[ \( $TMUX_VERSION_MAJOR -eq 2 -a $TMUX_VERSION_MINOR -ge 1\) -o $TMUX_VERSION_MAJOR -gt 2 ]' 'set -g mouse off'
+if-shell '[ \( $TMUX_VERSION_MAJOR -eq 2 -a $TMUX_VERSION_MINOR -lt 1\) -o $TMUX_VERSION_MAJOR -le 1 ]' 'set -g mode-mouse off'
+
+# fix pane_current_path on new window and splits
 if-shell '[ $TMUX_VERSION_MAJOR -gt 1 -o \( $TMUX_VERSION_MAJOR -eq 1 -a $TMUX_VERSION_MINOR -ge 8 \) ]' 'unbind c; bind c new-window -c "#{pane_current_path}"'
 if-shell '[ $TMUX_VERSION_MAJOR -gt 1 -o \( $TMUX_VERSION_MAJOR -eq 1 -a $TMUX_VERSION_MINOR -ge 8 \) ]' 'unbind s; bind s split-window -v -c "#{pane_current_path}"'
 if-shell '[ $TMUX_VERSION_MAJOR -gt 1 -o \( $TMUX_VERSION_MAJOR -eq 1 -a $TMUX_VERSION_MINOR -ge 8 \) ]' "unbind '\"'; bind '\"' split-window -v -c '#{pane_current_path}'"


### PR DESCRIPTION
Use powerline's `$TMUX_VERSION_MAJOR` and `$TMUX_VERSION_MINOR` to keep
support for older tmux versions.