### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/tmux-mem-cpu-load"]
 	path = vendor/tmux-mem-cpu-load
-	url = git://github.com/thewtex/tmux-mem-cpu-load.git
+	url = https://github.com/thewtex/tmux-mem-cpu-load.git


### PR DESCRIPTION
Use https protocol for submodule.

I periodically experience a connectivity issue when installing `tmux-config` from DigitalOcean droplets. 

```
➜  ~ git clone --recursive https://github.com/tony/tmux-config.git ~/.tmux
Cloning into '/home/ab/.tmux'...
remote: Enumerating objects: 468, done.
remote: Counting objects: 100% (28/28), done.
remote: Compressing objects: 100% (19/19), done.
remote: Total 468 (delta 14), reused 20 (delta 9), pack-reused 440
Receiving objects: 100% (468/468), 407.96 KiB | 11.33 MiB/s, done.
Resolving deltas: 100% (189/189), done.
Submodule 'vendor/tmux-mem-cpu-load' (git://github.com/thewtex/tmux-mem-cpu-load.git) registered for path 'vendor/tmux-mem-cpu-load'
Cloning into '/home/ab/.tmux/vendor/tmux-mem-cpu-load'...
fatal: unable to connect to github.com:
github.com[0: 140.82.121.3]: errno=Connection timed out

fatal: clone of 'git://github.com/thewtex/tmux-mem-cpu-load.git' into submodule path '/home/ab/.tmux/vendor/tmux-mem-cpu-load' failed
Failed to clone 'vendor/tmux-mem-cpu-load'. Retry scheduled
Cloning into '/home/ab/.tmux/vendor/tmux-mem-cpu-load'...
fatal: unable to connect to github.com:
github.com[0: 140.82.121.4]: errno=Connection timed out

fatal: clone of 'git://github.com/thewtex/tmux-mem-cpu-load.git' into submodule path '/home/ab/.tmux/vendor/tmux-mem-cpu-load' failed
Failed to clone 'vendor/tmux-mem-cpu-load' a second time, aborting
```

Cloning via HTTPS protocol is fixing that issue.
```
➜  ~ git clone --recursive https://github.com/armenak-baburyan/tmux-config.git ~/.tmux
Cloning into '/home/ab/.tmux'...
remote: Enumerating objects: 470, done.
remote: Counting objects: 100% (30/30), done.
remote: Compressing objects: 100% (21/21), done.
remote: Total 470 (delta 15), reused 20 (delta 9), pack-reused 440
Receiving objects: 100% (470/470), 408.58 KiB | 19.46 MiB/s, done.
Resolving deltas: 100% (190/190), done.
Submodule 'vendor/tmux-mem-cpu-load' (https://github.com/thewtex/tmux-mem-cpu-load.git) registered for path 'vendor/tmux-mem-cpu-load'
Cloning into '/home/ab/.tmux/vendor/tmux-mem-cpu-load'...
remote: Enumerating objects: 1231, done.
remote: Counting objects: 100% (135/135), done.
remote: Compressing objects: 100% (83/83), done.
remote: Total 1231 (delta 58), reused 109 (delta 52), pack-reused 1096
Receiving objects: 100% (1231/1231), 279.72 KiB | 13.32 MiB/s, done.
Resolving deltas: 100% (719/719), done.
Submodule path 'vendor/tmux-mem-cpu-load': checked out 'b6afa5c5e96620743f9466a8a41e1db6238de39d'
```